### PR TITLE
Simpler Check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "limiter"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Garrett Squire <garrettsquire@gmail.com>"]
 description = "Request body limiting for the Iron framework"
 repository = "https://github.com/gsquire/limiter"


### PR DESCRIPTION
I read the `Read` trait more and found a much simpler way to check the number of bytes in a request body.
